### PR TITLE
Extra lua_pushlstring?

### DIFF
--- a/redis-parser.c
+++ b/redis-parser.c
@@ -565,8 +565,6 @@ redis_build_query(lua_State *L)
 
     last = buf;
 
-    lua_pushlstring(L, buf, total);
-
     *last++ = '*';
     last = sprintf_num(last, n);
     *last++ = '\r'; *last++ = '\n';


### PR DESCRIPTION
Not sure why there is string push in redis_build_query before the query is built.
