### PR TITLE
use pkg-config instead of hardcoding paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,19 +9,19 @@ LUA_VERSION =   5.1
 # details.
 
 ## Linux/BSD
-PREFIX ?=          /usr/local
+PREFIX ?=          $(shell pkg-config luajit --variable=prefix)
 LDFLAGS +=         -shared
 
 ## OSX (Macports)
 #PREFIX ?=          /opt/local
 #LDFLAGS +=         -bundle -undefined dynamic_lookup
 
-LUA_INCLUDE_DIR ?= $(PREFIX)/include
-LUA_LIB_DIR ?=     $(PREFIX)/lib/lua/$(LUA_VERSION)
+LUA_INCLUDE_DIR ?= $(shell pkg-config luajit --cflags-only-I)
+LUA_LIB_DIR ?=     $(shell pkg-config luajit --variable=INSTALL_CMOD)
 
 #CFLAGS ?=          -g -Wall -pedantic -fno-inline
 CFLAGS ?=          -g -O -Wall
-override CFLAGS += -fpic -I$(LUA_INCLUDE_DIR)
+override CFLAGS += -fpic $(LUA_INCLUDE_DIR)
 
 INSTALL ?= install
 


### PR DESCRIPTION
Please accept this patch which uses pkg-config to figure out where to install things instead of relying on hardcoded ones..

I've assumed everyone is using luajit with lua-redis-parser (and with redis2-nginx-module), not sure if that assumption is correct ;-)

Makes my life easier when packaging modules into rpms.
